### PR TITLE
gifのpush

### DIFF
--- a/static/gif/key/key.gif
+++ b/static/gif/key/key.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fddf1d9651b9150971253513b69ffd490721d2679cc4db69a5880af455b48286
+size 38081002


### PR DESCRIPTION
gifが100Mを超えたため.gitattributesを使用した